### PR TITLE
fixup: pdtrk -> pdtrc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ extern "C" {
     /// Poisson distribution.
     fn pdtr(k: i32, m: f64) -> f64;
     /// Complemented Poisson distribution.
-    fn pdtrk(k: i32, m: f64) -> f64;
+    fn pdtrc(k: i32, m: f64) -> f64;
     /// Inverse of Poisson distribution.
     fn pdtri(k: i32, y: f64) -> f64;
 
@@ -504,7 +504,7 @@ extern "C" {
     /// Poisson distribution.
     fn pdtrf(k: i32, m: f32) -> f32;
     /// Complemented Poisson distribution.
-    fn pdtrkf(k: i32, m: f32) -> f32;
+    fn pdtrcf(k: i32, m: f32) -> f32;
     /// Inverse of Poisson distribution.
     fn pdtrif(k: i32, y: f32) -> f32;
 


### PR DESCRIPTION
**What does this do?** This fixes what appears to be a simple typo in the binding code. It appears that the binding meant to call the complementary Poisson distribution function was entered as `pdtrk` instead of `pdtrc`, as defined on line 137 of `cephes-double/pdtr.c`.

As a side note, I'm going to add tests for the non-tested functions that are currently linked in a followup PR. That PR will be branched off of this one.