### PR TITLE
Cephes double

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,60 +268,465 @@ pub mod unsafe_cephes_double {
     }
 }
 
-    /// Beta distribution.
-    fn btdtr(a: f64, b: f64, x: f64) -> f64;
+pub mod cephes_double {
+    use unsafe_cephes_double;
 
-    /// Chi-square distribution.
-    fn chdtr(df: f64, x: f64) -> f64;
-    /// Complemented chi-square distribution.
-    fn chdtrc(v: f64, x: f64) -> f64;
-    /// Inverse of complemented chi-square distribution.
-    fn chdtri(df: f64, y: f64) -> f64;
+    /// Function to compute the base-10 exponential of x
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// Returns 10 raised to the x power.
+    ///
+    /// Range reduction is accomplished by expressing the argument
+    /// as 10^x = 2^n 10^f, with |f| < 0.5 log10(2).
+    /// The Pade' form
+    ///
+    /// 10^x = 1 + 2x P( x^2)/( Q( x^2 ) - P( x^2 ) )
+    ///
+    /// is used to approximate 10^f.
+    ///
+    /// ACCURACY (Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :--------: | :----: | :-------: | :---: | :--: |
+    /// | IEEE       | -307,+307 | 30000 | 2.2e-16 | 5.5e-17 |
+    ///
+    /// ERROR MESSAGES:
+    ///
+    /// | message | condition | value returned |
+    /// | :-----: | :-------: | :------------: |
+    /// | exp10 underflow | x < -MAXL10 | 0.0  |
+    /// | exp10 overflow | x > MAXL10 | MAXNUM |
+    ///
+    /// IEEE arithmetic: MAXL10 = 308.2547155599167.
+    ///
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::exp10;
+    /// let x = 1.0f64;
+    /// exp10(x);
+    /// ```
+    pub fn exp10(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::exp10(x) }
+    }
 
-    /// F distribution.
-    fn fdtr(df1: i32, df2: i32, x: f64) -> f64;
-    /// Complemented F distribution.
-    fn fdtrc(df1: i32, df2: i32, x: f64) -> f64;
-    /// Inverse of complemented F distribution.
-    fn fdtri(df1: i32, df2: i32, p: f64) -> f64;
+    /// Function to accurately compute `exp(x) - 1` for small x
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::expm1;
+    /// let x = 1.0f64;
+    /// expm1(x);
+    /// ```
+    pub fn expm1(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::expm1(x) }
+    }
 
-    /// Gamma distribution.
-    fn gdtr(a: f64, b: f64, x: f64) -> f64;
-    /// Complemented gamma distribution.
-    fn gdtrc(a: f64, b: f64, x: f64) -> f64;
+    /// Function to accurately compute the exponential of a squared argument
+    ///
+    /// # Original Description from Stephen L. Moshier
+    ///
+    /// Computes y = exp(x*x) while suppressing error amplification
+    /// that would ordinarily arise from the inexactness of the
+    /// exponential argument x*x.
+    ///
+    /// If sign < 0, the result is inverted; i.e., y = exp(-x*x) .
+    ///
+    /// ACCURACY (Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :--------: | :----: | :------: | :--: | :--:|
+    /// | IEEE | -26.6, 26.6 | 10^7 | 3.9e-16 | 8.9e-17 |
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    /// * 'sign': An integer representing the sign of the exponent
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::expx2;
+    /// let x = 1.0f64;
+    /// expx2(x, -1);
+    /// ```
+    pub fn expx2(x: f64, sign: i32) -> f64 {
+        unsafe { unsafe_cephes_double::expx2(x, sign) }
+    }
 
-    /// Normal distribution.
-    fn ndtr(x: f64) -> f64;
-    /// Inverse of normal distribution.
-    fn ndtri(y: f64) -> f64;
+    /// Function to accurately compute the exponential integral of x
+    ///
+    /// The exponential integral is given by:
+    ///
+    /// $Ei(x) = -\int^{\infty}_{-x} \frac{e^{-t}}{t} dt$
+    ///
+    /// # Original Description from Stephen L. Moshier
+    ///
+    /// ACCURACY (Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :--------: | :----: | :------: | :--: | :--:|
+    /// | IEEE | 0, 100 | 50000 | 8.6e-16 | 1.3e-16 |
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::ei;
+    /// let x = 1.0f64;
+    /// ei(x);
+    /// ```
+    pub fn ei(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::ei(x) }
+    }
 
-    /// Poisson distribution.
-    fn pdtr(k: i32, m: f64) -> f64;
-    /// Complemented Poisson distribution.
-    fn pdtrc(k: i32, m: f64) -> f64;
-    /// Inverse of Poisson distribution.
-    fn pdtri(k: i32, y: f64) -> f64;
+    /// Function to accurately compute the error function of x
+    ///
+    /// The error function is given by:
+    ///
+    /// $Erf(x) = \frac{2}{\sqrt{pi}} -\int^{x}_{0} e^{-t^2} dt$
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::erf;
+    /// let x = 1.0f64;
+    /// erf(x);
+    /// ```
+    pub fn erf(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::erf(x) }
+    }
 
-    /// Student's t distribution.
-    fn stdtr(k: i16, t: f64) -> f64;
-    /// Inverse of Student's t distribution.
-    fn stdtri(k: i32, p: f64) -> f64;
+    /// Function to accurately compute the complementary error function of x
+    ///
+    /// The error function is given by:
+    ///
+    /// $Erf(x) = 1 + \frac{2}{\sqrt{pi}} -\int^{x}_{0} e^{-t^2} dt$
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::erfc;
+    /// let x = 1.0f64;
+    /// erfc(x);
+    /// ```
+    pub fn erfc(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::erfc(x) }
+    }
 
-    // Misc special functions
-    /// Airy function.
-    fn airy(x: f64, ai: &mut f64, aip: &mut f64, bi: &mut f64, bip: &mut f64) -> i32;
-    /// Dawson's integral.
-    fn dawsn(x: f64) -> f64;
-    /// Fresnel integral.
-    fn fresnl(x: f64, s: &mut f64, c: &mut f64);
-    /// Integral of Planck's black body radiation formula.
-    fn plancki(lambda: f64, temperature: f64) -> f64;
-    /// Struve function.
-    fn struve(v: f64, x: f64) -> f64;
-    /// Riemann zeta function.
-    fn zetac(x: f64) -> f64;
-    /// Riemann zeta function of two arguments.
-    fn zeta(x: f64, q: f64) -> f64;
+    /// Function to accurately compute `log(1 + x)`
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::log1p;
+    /// let x = 0.1f64;
+    /// log1p(x);
+    /// ```
+    pub fn log1p(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::log1p(x) }
+    }
+
+    /// Function to accurately compute the dilogarithm function
+    ///
+    /// Spence's function is a special case of the polylogarithm function, and
+    /// is defined as:
+    ///
+    /// $ Li_2(x) = \int^x_1 \frac{ln(t)}{t - 1} du
+    ///
+    /// Note, this implies that the domain has been shifted by 1 from the
+    /// standard definition (as per wikipedia) of:
+    ///
+    /// $ Li_2(x) = - \int^x_0 \frac{ ln(1 - t) }{ t } dt
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// Computes the integral for x >= 0.  A rational approximation gives the
+    /// integral in the interval (0.5, 1.5).  Transformation formulas for 1/x
+    /// and 1-x are employed outside the basic expansion range.
+    ///
+    /// ACCURACY(Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :---: | :--: | :--: | :--: | :--: | :--: |
+    /// | IEEE  | 0,4 | 30000 | 3.9e-15 | 5.4e-16 |
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::spence;
+    /// let x = 0.1f64;
+    /// spence(x);
+    /// ```
+    pub fn spence(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::spence(x) }
+    }
+
+    /// Function to accurately compute `cos(x) - 1` for small x
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::cosm1;
+    /// let x = 0.1f64;
+    /// cosm1(x);
+    /// ```
+    pub fn cosm1(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::cosm1(x) }
+    }
+
+    /// Function to accurately compute sine and cosine integrals
+    ///
+    /// The sine integral is defined as:
+    ///
+    /// $ Si(x) = \int_0^{\infty} \frac{ sin(t) }{t} dt $
+    ///
+    /// and the cosine integral is defined as:
+    ///
+    /// $ Ci(x) = -\int_x^{\infty} \frac{ cos(t) }{t} dt $
+    ///
+    /// which reduces to:
+    ///
+    /// $ Ci(x) = \gamma + ln(x) + \int_0^x \frac{cos(t) - 1}{t} dt $
+    ///
+    /// where $\gamma$ is the euler constant.
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// The integrals are approximated by rational functions.
+    /// For x > 8 auxiliary functions f(x) and g(x) are employed
+    /// such that
+    ///
+    /// Ci(x) = f(x) sin(x) - g(x) cos(x)
+    /// Si(x) = pi/2 - f(x) cos(x) - g(x) sin(x)
+    ///
+    /// ACCURACY(Absolute error, except relative when > 1):
+    ///
+    /// | arithmetic | Function | domain | # trials | peak | rms |
+    /// | :---: | :--: | :--: | :--: | :--: | :--: | :--: |
+    /// | IEEE | Si | 0,50 | 30000 | 4.4e-16 | 7.3e-17 |
+    /// | IEEE | Ci | 0,50 | 30000 | 6.9e-16 | 5.1e-17 |
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    /// * `Si`: A mutable double precision number that will return the sine
+    ///         integral value
+    /// * `Ci`: A mutable double precision number that will return the cosine
+    ///         integral value
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::sici;
+    /// let x = 0.1f64;
+    /// let mut si = 0.0_f64;
+    /// let mut ci = 0.0_f64;
+    /// let mut code = 0.0_f64;
+    /// code = sici(0.5_f64, &mut si, &mut ci);
+    /// ```
+    pub fn sici(x: f64, si: &mut f64, ci: &mut f64) -> f64 {
+        unsafe { unsafe_cephes_double::sici(x, si, ci) }
+    }
+
+    /// Function to accurately compute hyperbolic sine and cosine integrals
+    ///
+    /// The hyperbolic sine integral is defined as:
+    ///
+    /// $ Shi(x) = \int_0^{\infty} \frac{ sinh(t) }{t} dt $
+    ///
+    /// and the hyperbolic cosine integral is defined as:
+    ///
+    /// $ Chi(x) = -\int_x^{\infty} \frac{ cosh(t) }{t} dt $
+    ///
+    /// which reduces to:
+    ///
+    /// $ Chi(x) = \gamma + ln(x) + \int_0^x \frac{cosh(t) - 1}{t} dt $
+    ///
+    /// where $\gamma$ is the euler constant.
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// The integrals are approximated by rational functions.
+    /// For x > 8 auxiliary functions f(x) and g(x) are employed
+    /// such that
+    ///
+    /// Ci(x) = f(x) sin(x) - g(x) cos(x)
+    /// Si(x) = pi/2 - f(x) cos(x) - g(x) sin(x)
+    ///
+    /// ACCURACY(Relative error)):
+    ///
+    /// | arithmetic | Function | domain | # trials | peak | rms |
+    /// | :---: | :--: | :--: | :--: | :--: | :--: | :--: |
+    /// | IEEE | Shi | 0,88 | 30000 | 6.9-16 | 1.6e-16 |
+    ///
+    /// ACCURACY(Absolute error, except relative when |Chi| > 1):
+    ///
+    /// | arithmetic | Function | domain | # trials | peak | rms |
+    /// | :---: | :--: | :--: | :--: | :--: | :--: | :--: |
+    /// | IEEE | Chi | 0,88 | 30000 | 8.4e-16 | 1.4e-16 |
+    ///
+    /// # Arguments
+    /// * `x`: A double precision number
+    /// * `Shi`: A mutable double precision number that will return the
+    ///          hyperbolic sine integral value
+    /// * `Chi`: A mutable double precision number that will return the
+    ///          hyperbolic cosine integral value
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::shichi;
+    /// let x = 0.1f64;
+    /// let mut shi = 0.0_f64;
+    /// let mut chi = 0.0_f64;
+    /// shichi(0.5_f64, &mut shi, &mut chi);
+    /// ```
+    pub fn shichi(x: f64, chi: &mut f64, shi: &mut f64){
+        unsafe { unsafe_cephes_double::shichi(x, chi, shi) }
+    }
+
+    /// Function to compute the beta function.
+    ///
+    /// The beta function is given by:
+    ///
+    /// $B(a, b) = \int_0^1 t^{a - 1} ( 1 - t )^{b - 1} dt $
+    ///
+    /// which simplifies to
+    ///
+    /// $ B(a, b) = \frac{ \Gamma(a) \Gamma(b)}{ \Gamma(a + b) } $
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// For large arguments the logarithm of the function is
+    /// evaluated using lgam(), then exponentiated.
+    ///
+    /// ACCURACY (Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :--------: | :----: | :------: | :--: | :-: |
+    /// | IEEE       | 0,30   | 30000    | 8.1e-14 | 1.1e-14 |
+    ///
+    /// ERROR MESSAGES:
+    ///
+    /// | message   | condition | value returned |
+    /// | :-------: | :--------: | :----------: |
+    /// | beta overflow | log(beta) > MAXLOG | 0.0 |
+    /// | beta overflow | a or b <0 integer      | 0.0 |
+    ///
+    /// # Arguments
+    /// * `a`: A double precision parameter, assumed to be greater than 0
+    /// * `b`: A double precision parameter, assumed to be greater than 0
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::beta;
+    /// let a = 0.1f64;
+    /// let b = 0.2f64;
+    /// beta(a, b);
+    /// ```
+    pub fn beta(a: f64, b: f64) -> f64 {
+        unsafe { unsafe_cephes_double::beta(a, b) }
+    }
+
+    /// Function to compute the regularized incomplete beta function.
+    ///
+    /// The regularized incomplete beta function is given by:
+    ///
+    /// $I_x(a, b) = \frac{1}{B(a, b)} \int_0^x t^{a - 1} ( 1 - t )^{b - 1} dt $
+    ///
+    /// and for $x = 1$, the regularized incomplete beta function evaluates to
+    /// exactly 1. Note, $ 1 - I_x(a, b) = I_{1 - x}(a, b)$.
+    ///
+    /// # Original Description from Stephen L. Moshier
+    /// The integral is evaluated by a continued fraction expansion
+    /// or, when b*x is small, by a power series.
+    ///
+    /// ACCURACY (Relative error):
+    ///
+    /// | arithmetic | domain | # trials | peak | rms |
+    /// | :--------: | :----: | :------: | :--: | :-: |
+    /// | IEEE       | 0,5    | 10000    | 6.9e-15 | 4.5e-16 |
+    /// | IEEE | 0,85 | 250000 | 2.2e-13 | 1.7e-14 |
+    /// | IEEE | 0,1000   |  30000  |  5.3e-12 | 6.3e-13 |
+    /// | IEEE | 0,10000  | 250000  |  9.3e-11 | 7.1e-12 |
+    /// | IEEE | 0,100000 |  10000  |  8.7e-10 | 4.8e-11 |
+    ///
+    /// ERROR MESSAGES:
+    ///
+    /// | message   | condition | value returned |
+    /// | :-------: | :--------: | :----------: |
+    /// | incbet domain | x<0, x>1 | 0.0 |
+    /// | incbet underflow | - | 0.0 |
+    ///
+    /// # Arguments
+    /// * `a`: A double precision parameter, assumed to be greater than 0
+    /// * `b`: A double precision parameter, assumed to be greater than 0
+    /// * `x`: A double precision parameter, assumed to be between 0 and 1
+    ///
+    /// # Example
+    /// ```
+    /// use special_fun::cephes_double::incbet;
+    /// let a = 0.1f64;
+    /// let b = 0.2f64;
+    /// incbet(a, b, 0.5f64);
+    /// ```
+    pub fn incbet(a: f64, b: f64, x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::incbet(a, b, x) }
+    }
+
+    /// Inverse of incomplete beta integral.
+    pub fn incbi(a: f64, b: f64, y: f64) -> f64 {
+        unsafe { unsafe_cephes_double::incbi(a, b, y) }
+    }
+
+    /// Gamma function.
+    pub fn gamma(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::gamma(x) }
+    }
+
+    /// Reciprocal gamma function.
+    pub fn rgamma(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::rgamma(x) }
+    }
+
+    /// Natural logarithm of gamma function.
+    pub fn lgam(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::lgam(x) }
+    }
+
+    /// Regularized incomplete gamma integral.
+    pub fn igam(a: f64, x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::igam(a, x) }
+    }
+
+    /// Complemented incomplete gamma integral.
+    pub fn igamc(a: f64, x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::igamc(a, x) }
+    }
+
+    /// Inverse of complemented incomplete gamma integral.
+    pub fn igami(a: f64, p: f64) -> f64 {
+        unsafe { unsafe_cephes_double::igami(a, p) }
+    }
+
+    /// Psi (digamma) function.
+    pub fn psi(x: f64) -> f64 {
+        unsafe { unsafe_cephes_double::psi(x) }
+    }
+
+    /// Factorial function.
+    pub fn fac(i: i32) -> f64 {
+        unsafe { unsafe_cephes_double::fac(i) }
+    }
 }
 
 // single precision

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,211 +4,269 @@ use core::ops::{Add, Sub};
 
 // double precision
 #[allow(dead_code)]
-extern "C" {
-    // Floating point numeric utilities
-    /// Round to nearest or event integer valued f64.
-    fn round(x: f64) -> f64;
-    /// Largest integer less than or equal to x.
-    fn floor(x: f64) -> f64;
-    /// Smallest integer greater than or equal to x.
-    fn ceil(x: f64) -> f64;
-    /// Return the significand between 0.5 and 1. Write exponent to expnt.
-    /// x = y * 2**expn
-    fn frexp(x: f64, expnt: &mut i32) -> f64;
-    /// Multiply x by 2**n.
-    fn ldexp(x: f64, n: i32) -> f64;
-    /// Absolute value.
-    fn fabs(x: f64) -> f64;
-    /// Return 1 if the sign bit of x is 1, else 0.
-    fn signbit(x: f64) -> i32;
-    /// Return 1 if x is NaN, else 0.
-    fn isnan(x: f64) -> i32;
-    /// Return 1 if x is finite, else 0.
-    fn isfinite(x: f64) -> i32;
+pub mod unsafe_cephes_double {
+    extern "C" {
+        // Floating point numeric utilities
+        /// Round to nearest or event integer valued f64.
+        pub fn round(x: f64) -> f64;
+        /// Largest integer less than or equal to x.
+        pub fn floor(x: f64) -> f64;
+        /// Smallest integer greater than or equal to x.
+        pub fn ceil(x: f64) -> f64;
+        /// Return the significand between 0.5 and 1. Write exponent to expnt.
+        /// x = y * 2**expn
+        pub fn frexp(x: f64, expnt: &mut i32) -> f64;
+        /// Multiply x by 2**n.
+        pub fn ldexp(x: f64, n: i32) -> f64;
+        /// Absolute value.
+        pub fn fabs(x: f64) -> f64;
+        /// Return 1 if the sign bit of x is 1, else 0.
+        pub fn signbit(x: f64) -> i32;
+        /// Return 1 if x is NaN, else 0.
+        pub fn isnan(x: f64) -> i32;
+        /// Return 1 if x is finite, else 0.
+        pub fn isfinite(x: f64) -> i32;
 
-    // Roots
-    /// Cube root.
-    fn cbrt(x: f64) -> f64;
-    /// Square root.
-    fn sqrt(x: f64) -> f64;
-    /// Integer square root.
-    fn lsqrt(x: i64) -> i64;
+        // Roots
+        /// Cube root.
+        pub fn cbrt(x: f64) -> f64;
+        /// Square root.
+        pub fn sqrt(x: f64) -> f64;
+        /// Integer square root.
+        pub fn lsqrt(x: i64) -> i64;
 
-    // Exponential functions
-    /// Exponential function.
-    fn exp(x: f64) -> f64;
-    /// Base 10 exponential function.
-    fn exp10(x: f64) -> f64;
-    /// Base 2 exponential function.
-    fn exp2(x: f64) -> f64;
-    /// Compute accurately exponential of squared argument.
-    fn expm1(x: f64) -> f64;
-    /// Compute accurately exp(x) - 1 for x close to 0.
-    fn expx2(x: f64, sign: i32) -> f64;
-    /// Exponential integral.
-    fn ei(x: f64) -> f64;
-    /// Error function.
-    fn erf(x: f64) -> f64;
-    /// Complementary error function.
-    fn erfc(x: f64) -> f64;
-    /// Power function.
-    fn pow(x: f64, y: f64) -> f64;
-    /// Integer power function.
-    fn powi(x: f64, n: i32) -> f64;
+        // Exponential functions
+        /// Exponential function.
+        pub fn exp(x: f64) -> f64;
+        /// Base 10 exponential function.
+        pub fn exp10(x: f64) -> f64;
+        /// Base 2 exponential function.
+        pub fn exp2(x: f64) -> f64;
+        /// Compute accurately exponential of squared argument.
+        pub fn expm1(x: f64) -> f64;
+        /// Compute accurately exp(x) - 1 for x close to 0.
+        pub fn expx2(x: f64, sign: i32) -> f64;
+        /// Exponential integral.
+        pub fn ei(x: f64) -> f64;
+        /// Error function.
+        pub fn erf(x: f64) -> f64;
+        /// Complementary error function.
+        pub fn erfc(x: f64) -> f64;
+        /// Power function.
+        pub fn pow(x: f64, y: f64) -> f64;
+        /// Integer power function.
+        pub fn powi(x: f64, n: i32) -> f64;
 
-    // Logarithmic functions
-    /// Natural logarithm.
-    fn log(x: f64) -> f64;
-    /// Common logarithm.
-    fn log10(x: f64) -> f64;
-    /// Base 2 logarithm.
-    fn log2(x: f64) -> f64;
-    /// Compute accurately log(1 + x) for x close to 0.
-    fn log1p(x: f64) -> f64;
-    /// Dilogarithm (Spence's function).
-    fn spence(x: f64) -> f64;
+        // Logarithmic functions
+        /// Natural logarithm.
+        pub fn log(x: f64) -> f64;
+        /// Common logarithm.
+        pub fn log10(x: f64) -> f64;
+        /// Base 2 logarithm.
+        pub fn log2(x: f64) -> f64;
+        /// Compute accurately log(1 + x) for x close to 0.
+        pub fn log1p(x: f64) -> f64;
+        /// Dilogarithm (Spence's function).
+        pub fn spence(x: f64) -> f64;
 
-    // Trigonometric functions
-    /// Circular sine.
-    fn sin(x: f64) -> f64;
-    /// Circular cosine.
-    fn cos(x: f64) -> f64;
-    /// Circular tangent.
-    fn tan(x: f64) -> f64;
-    /// Inverse circular sine.
-    fn asin(x: f64) -> f64;
-    /// Inverse circular cosine.
-    fn acos(x: f64) -> f64;
-    /// Inverse circular tangent.
-    fn atan(x: f64) -> f64;
-    /// Quadrant-correct inverse circular tangent.
-    fn atan2(y: f64, x: f64) -> f64;
-    /// Compute accurately cos(x) - 1 for x close to 0.
-    fn cosm1(x: f64) -> f64;
-    /// Sine and cosine integrals.
-    fn sici(x: f64, si: &mut f64, ci: &mut f64) -> f64;
+        // Trigonometric functions
+        /// Circular sine.
+        pub fn sin(x: f64) -> f64;
+        /// Circular cosine.
+        pub fn cos(x: f64) -> f64;
+        /// Circular tangent.
+        pub fn tan(x: f64) -> f64;
+        /// Inverse circular sine.
+        pub fn asin(x: f64) -> f64;
+        /// Inverse circular cosine.
+        pub fn acos(x: f64) -> f64;
+        /// Inverse circular tangent.
+        pub fn atan(x: f64) -> f64;
+        /// Quadrant-correct inverse circular tangent.
+        pub fn atan2(y: f64, x: f64) -> f64;
+        /// Compute accurately cos(x) - 1 for x close to 0.
+        pub fn cosm1(x: f64) -> f64;
+        /// Sine and cosine integrals.
+        pub fn sici(x: f64, si: &mut f64, ci: &mut f64) -> f64;
 
-    // Hyperbolic functions
-    /// Hyperbolic sine.
-    fn sinh(x: f64) -> f64;
-    /// Hyperbolic cosine.
-    fn cosh(x: f64) -> f64;
-    /// Hyperbolic tangent.
-    fn tanh(x: f64) -> f64;
-    /// Inverse hyperbolic sine.
-    fn asinh(x: f64) -> f64;
-    /// Inverse hyperbolic cosine.
-    fn acosh(x: f64) -> f64;
-    /// Inverse hyperbolic tangent.
-    fn atanh(x: f64) -> f64;
-    /// Hyperbolic sine and cosine integrals.
-    fn shichi(x: f64, chi: &mut f64, shi: &mut f64);
+        // Hyperbolic functions
+        /// Hyperbolic sine.
+        pub fn sinh(x: f64) -> f64;
+        /// Hyperbolic cosine.
+        pub fn cosh(x: f64) -> f64;
+        /// Hyperbolic tangent.
+        pub fn tanh(x: f64) -> f64;
+        /// Inverse hyperbolic sine.
+        pub fn asinh(x: f64) -> f64;
+        /// Inverse hyperbolic cosine.
+        pub fn acosh(x: f64) -> f64;
+        /// Inverse hyperbolic tangent.
+        pub fn atanh(x: f64) -> f64;
+        /// Hyperbolic sine and cosine integrals.
+        pub fn shichi(x: f64, chi: &mut f64, shi: &mut f64);
 
-    // Beta functions
-    /// Beta function.
-    fn beta(a: f64, b: f64) -> f64;
-    /// Regularized incomplete beta function.
-    fn incbet(a: f64, b: f64, x: f64) -> f64;
-    /// Inverse of incomplete beta integral.
-    fn incbi(a: f64, b: f64, y: f64) -> f64;
+        // Beta functions
+        /// Beta function.
+        pub fn beta(a: f64, b: f64) -> f64;
+        /// Regularized incomplete beta function.
+        pub fn incbet(a: f64, b: f64, x: f64) -> f64;
+        /// Inverse of incomplete beta integral.
+        pub fn incbi(a: f64, b: f64, y: f64) -> f64;
 
-    // Gamma functions
-    /// Gamma function.
-    fn gamma(x: f64) -> f64;
-    /// Reciprocal gamma function.
-    fn rgamma(x: f64) -> f64;
-    /// Natural logarithm of gamma function.
-    fn lgam(x: f64) -> f64;
-    /// Regularized incomplete gamma integral.
-    fn igam(a: f64, x: f64) -> f64;
-    /// Complemented incomplete gamma integral.
-    fn igamc(a: f64, x: f64) -> f64;
-    /// Inverse of complemented incomplete gamma integral.
-    fn igami(a: f64, p: f64) -> f64;
-    /// Psi (digamma) function.
-    fn psi(x: f64) -> f64;
-    /// Factorial function.
-    fn fac(i: i32) -> f64;
+        // Gamma functions
+        /// Gamma function.
+        pub fn gamma(x: f64) -> f64;
+        /// Reciprocal gamma function.
+        pub fn rgamma(x: f64) -> f64;
+        /// Natural logarithm of gamma function.
+        pub fn lgam(x: f64) -> f64;
+        /// Regularized incomplete gamma integral.
+        pub fn igam(a: f64, x: f64) -> f64;
+        /// Complemented incomplete gamma integral.
+        pub fn igamc(a: f64, x: f64) -> f64;
+        /// Inverse of complemented incomplete gamma integral.
+        pub fn igami(a: f64, p: f64) -> f64;
+        /// Psi (digamma) function.
+        pub fn psi(x: f64) -> f64;
+        /// Factorial function.
+        pub fn fac(i: i32) -> f64;
 
-    // Bessel functions
-    /// Bessel function of order zero.
-    fn j0(x: f64) -> f64;
-    /// Bessel function of order one.
-    fn j1(x: f64) -> f64;
-    /// Bessel function of integer order.
-    fn jn(n: i32, x: f64) -> f64;
-    /// Bessel function of real order.
-    fn jv(n: f64, x: f64) -> f64;
+        // Bessel functions
+        /// Bessel function of order zero.
+        pub fn j0(x: f64) -> f64;
+        /// Bessel function of order one.
+        pub fn j1(x: f64) -> f64;
+        /// Bessel function of integer order.
+        pub fn jn(n: i32, x: f64) -> f64;
+        /// Bessel function of real order.
+        pub fn jv(n: f64, x: f64) -> f64;
 
-    /// Bessel function of the second kind, order zero.
-    fn y0(x: f64) -> f64;
-    /// Bessel function of the second kind, order one.
-    fn y1(x: f64) -> f64;
-    /// Bessel function of the second kind, integer order.
-    fn yn(n: i32, x: f64) -> f64;
-    /// Bessel function of the second kind, real order.
-    fn yv(v: f64, x: f64) -> f64;
+        /// Bessel function of the second kind, order zero.
+        pub fn y0(x: f64) -> f64;
+        /// Bessel function of the second kind, order one.
+        pub fn y1(x: f64) -> f64;
+        /// Bessel function of the second kind, integer order.
+        pub fn yn(n: i32, x: f64) -> f64;
+        /// Bessel function of the second kind, real order.
+        pub fn yv(v: f64, x: f64) -> f64;
 
-    /// Modified Bessel function of order zero.
-    fn i0(x: f64) -> f64;
-    /// Modified Bessel function of order zero, exponentially scaled.
-    fn i0e(x: f64) -> f64;
-    /// Modified Bessel function of order one.
-    fn i1(x: f64) -> f64;
-    /// Modified Bessel function of order one, exponentially scaled.
-    fn i1e(x: f64) -> f64;
-    /// Modified Bessel function of real order.
-    fn iv(v: f64, x: f64) -> f64;
+        /// Modified Bessel function of order zero.
+        pub fn i0(x: f64) -> f64;
+        /// Modified Bessel function of order zero, exponentially scaled.
+        pub fn i0e(x: f64) -> f64;
+        /// Modified Bessel function of order one.
+        pub fn i1(x: f64) -> f64;
+        /// Modified Bessel function of order one, exponentially scaled.
+        pub fn i1e(x: f64) -> f64;
+        /// Modified Bessel function of real order.
+        pub fn iv(v: f64, x: f64) -> f64;
 
-    /// Modified Bessel function of the third kind, order zero.
-    fn k0(x: f64) -> f64;
-    /// Modified Bessel function of the third kind, order zero,
-    /// exponentially scaled.
-    fn k0e(x: f64) -> f64;
-    /// Modified Bessel function of the third kind, order one.
-    fn k1(x: f64) -> f64;
-    /// Modified Bessel function of the third kind, order one,
-    /// exponentially scaled.
-    fn k1e(x: f64) -> f64;
-    /// Modified Bessel function of the third kind, integer order.
-    fn kn(n: i32, x: f64) -> f64;
+        /// Modified Bessel function of the third kind, order zero.
+        pub fn k0(x: f64) -> f64;
+        /// Modified Bessel function of the third kind, order zero,
+        /// exponentially scaled.
+        pub fn k0e(x: f64) -> f64;
+        /// Modified Bessel function of the third kind, order one.
+        pub fn k1(x: f64) -> f64;
+        /// Modified Bessel function of the third kind, order one,
+        /// exponentially scaled.
+        pub fn k1e(x: f64) -> f64;
+        /// Modified Bessel function of the third kind, integer order.
+        pub fn kn(n: i32, x: f64) -> f64;
 
-    // Elliptic functions
-    /// Incomplete elliptic integral of the first kind.
-    fn ellik(phi: f64, m: f64) -> f64;
-    /// Incomplete elliptic integral of the second kind.
-    fn ellie(phi: f64, m: f64) -> f64;
-    /// Complete elliptic integral of the first kind.
-    fn ellpk(m1: f64) -> f64;
-    /// Complete elliptic integral of the second kind.
-    fn ellpe(m1: f64) -> f64;
-    /// Jacobian elliptic function.
-    fn ellpj(u: f64, m: f64, sn: &mut f64, cn: &mut f64, dn: &mut f64, phi: &mut f64) -> i32;
+        // Elliptic functions
+        /// Incomplete elliptic integral of the first kind.
+        pub fn ellik(phi: f64, m: f64) -> f64;
+        /// Incomplete elliptic integral of the second kind.
+        pub fn ellie(phi: f64, m: f64) -> f64;
+        /// Complete elliptic integral of the first kind.
+        pub fn ellpk(m1: f64) -> f64;
+        /// Complete elliptic integral of the second kind.
+        pub fn ellpe(m1: f64) -> f64;
+        /// Jacobian elliptic function.
+        pub fn ellpj(u: f64, m: f64, sn: &mut f64, cn: &mut f64, dn: &mut f64, phi: &mut f64) -> i32;
 
-    // Hypergeometric functions
-    /// Confluent hypergeometric function 1F1.
-    fn hyperg(a: f64, b: f64, x: f64) -> f64;
-    /// Hypergeometric function 1F2.
-    fn onef2(a: f64, b: f64, c: f64, x: f64, err: &mut f64) -> f64;
-    /// Gauss hypergeometric function 2F1.
-    fn hyp2f1(a: f64, b: f64, c: f64, x: f64) -> f64;
-    /// Hypergeometric function 3F0.
-    fn threef0(a: f64, b: f64, c: f64, x: f64, err: &mut f64) -> f64;
+        // Hypergeometric functions
+        /// Confluent hypergeometric function 1F1.
+        pub fn hyperg(a: f64, b: f64, x: f64) -> f64;
+        /// Hypergeometric function 1F2.
+        pub fn onef2(a: f64, b: f64, c: f64, x: f64, err: &mut f64) -> f64;
+        /// Gauss hypergeometric function 2F1.
+        pub fn hyp2f1(a: f64, b: f64, c: f64, x: f64) -> f64;
+        /// Hypergeometric function 3F0.
+        pub fn threef0(a: f64, b: f64, c: f64, x: f64, err: &mut f64) -> f64;
 
-    // Distributions
-    /// Binomial distribution.
-    fn bdtr(k: i32, n: i32, p: f64) -> f64;
-    /// Complemented binomial distribution.
-    fn bdtrc(k: i32, n: i32, p: f64) -> f64;
-    /// Inverse of binomial distribution.
-    fn bdtri(k: i32, n: i32, y: f64) -> f64;
+        // Distributions
+        /// Binomial distribution.
+        pub fn bdtr(k: i32, n: i32, p: f64) -> f64;
+        /// Complemented binomial distribution.
+        pub fn bdtrc(k: i32, n: i32, p: f64) -> f64;
+        /// Inverse of binomial distribution.
+        pub fn bdtri(k: i32, n: i32, y: f64) -> f64;
 
-    /// Negative binomial distribution.
-    fn nbdtr(k: i32, n: i32, p: f64) -> f64;
-    /// Complemented negative binomial distribution.
-    fn nbdtrc(k: i32, n: i32, p: f64) -> f64;
-    /// Inverse of negative binomial distribution.
-    fn nbdtri(k: i32, n: i32, p: f64) -> f64;
+        /// Negative binomial distribution.
+        pub fn nbdtr(k: i32, n: i32, p: f64) -> f64;
+        /// Complemented negative binomial distribution.
+        pub fn nbdtrc(k: i32, n: i32, p: f64) -> f64;
+        /// Inverse of negative binomial distribution.
+        pub fn nbdtri(k: i32, n: i32, p: f64) -> f64;
+
+        /// Beta distribution.
+        pub fn btdtr(a: f64, b: f64, x: f64) -> f64;
+
+        /// Chi-square distribution.
+        pub fn chdtr(df: f64, x: f64) -> f64;
+        /// Complemented chi-square distribution.
+        pub fn chdtrc(v: f64, x: f64) -> f64;
+        /// Inverse of complemented chi-square distribution.
+        pub fn chdtri(df: f64, y: f64) -> f64;
+
+        /// F distribution.
+        pub fn fdtr(df1: i32, df2: i32, x: f64) -> f64;
+        /// Complemented F distribution.
+        pub fn fdtrc(df1: i32, df2: i32, x: f64) -> f64;
+        /// Inverse of complemented F distribution.
+        pub fn fdtri(df1: i32, df2: i32, p: f64) -> f64;
+
+        /// Gamma distribution.
+        pub fn gdtr(a: f64, b: f64, x: f64) -> f64;
+        /// Complemented gamma distribution.
+        pub fn gdtrc(a: f64, b: f64, x: f64) -> f64;
+
+        /// Normal distribution.
+        pub fn ndtr(x: f64) -> f64;
+        /// Inverse of normal distribution.
+        pub fn ndtri(y: f64) -> f64;
+
+        /// Poisson distribution.
+        pub fn pdtr(k: i32, m: f64) -> f64;
+        /// Complemented Poisson distribution.
+        pub fn pdtrc(k: i32, m: f64) -> f64;
+        /// Inverse of Poisson distribution.
+        pub fn pdtri(k: i32, y: f64) -> f64;
+
+        /// Student's t distribution.
+        pub fn stdtr(k: i16, t: f64) -> f64;
+        /// Inverse of Student's t distribution.
+        pub fn stdtri(k: i32, p: f64) -> f64;
+
+        // Misc special functions
+        /// Airy function.
+        pub fn airy(x: f64, ai: &mut f64, aip: &mut f64, bi: &mut f64, bip: &mut f64) -> i32;
+        /// Dawson's integral.
+        pub fn dawsn(x: f64) -> f64;
+        /// Fresnel integral.
+        pub fn fresnl(x: f64, s: &mut f64, c: &mut f64);
+        /// Integral of Planck's black body radiation formula.
+        pub fn plancki(lambda: f64, temperature: f64) -> f64;
+        /// Struve function.
+        pub fn struve(v: f64, x: f64) -> f64;
+        /// Riemann zeta function.
+        pub fn zetac(x: f64) -> f64;
+        /// Riemann zeta function of two arguments.
+        pub fn zeta(x: f64, q: f64) -> f64;
+    }
+}
 
     /// Beta distribution.
     fn btdtr(a: f64, b: f64, x: f64) -> f64;
@@ -598,89 +656,89 @@ pub trait FloatSpecial: Copy + Add<Output=Self> + Sub<Output=Self> {
 
 impl FloatSpecial for f64 {
     fn beta(self, b: f64) -> f64 {
-        unsafe { beta(self, b) }
+        unsafe { unsafe_cephes_double::beta(self, b) }
     }
     fn betainc(self, a: f64, b: f64) -> f64 {
-        unsafe { incbet(a, b, self) }
+        unsafe { unsafe_cephes_double::incbet(a, b, self) }
     }
     fn betainc_inv(self, a: f64, b: f64) -> f64 {
-        unsafe { incbi(a, b, self) }
+        unsafe { unsafe_cephes_double::incbi(a, b, self) }
     }
 
     fn factorial(self) -> f64 {
-        unsafe { gamma(self + 1.0) }
+        unsafe { unsafe_cephes_double::gamma(self + 1.0) }
     }
     fn gamma(self) -> f64 {
-        unsafe { gamma(self) }
+        unsafe { unsafe_cephes_double::gamma(self) }
     }
     fn rgamma(self) -> f64 {
-        unsafe { rgamma(self) }
+        unsafe { unsafe_cephes_double::rgamma(self) }
     }
     fn loggamma(self) -> f64 {
-        unsafe { lgam(self) }
+        unsafe { unsafe_cephes_double::lgam(self) }
     }
 
     fn gammainc(self, a: f64) -> f64 {
-        unsafe { igam(a, self) }
+        unsafe { unsafe_cephes_double::igam(a, self) }
     }
     fn gammac(self, a: f64) -> f64 {
-        unsafe { igamc(a, self) }
+        unsafe { unsafe_cephes_double::igamc(a, self) }
     }
     fn gammac_inv(self, a: f64) -> f64 {
-        unsafe { igami(a, self) }
+        unsafe { unsafe_cephes_double::igami(a, self) }
     }
 
     fn digamma(self) -> f64 {
-        unsafe { psi(self) }
+        unsafe { unsafe_cephes_double::psi(self) }
     }
 
     fn erf(self) -> f64 {
-        unsafe { erf(self) }
+        unsafe { unsafe_cephes_double::erf(self) }
     }
     fn erfc(self) -> f64 {
-        unsafe { erfc(self) }
+        unsafe { unsafe_cephes_double::erfc(self) }
     }
 
     fn hyp1f1(self, a: f64, b: f64) -> f64 {
-        unsafe { hyperg(a, b, self) }
+        unsafe { unsafe_cephes_double::hyperg(a, b, self) }
     }
     fn hyp1f2(self, a: f64, b: f64, c: f64) -> f64 {
         let mut err = 0.0;
-        unsafe { onef2(a, b, c, self, &mut err) }
+        unsafe { unsafe_cephes_double::onef2(a, b, c, self, &mut err) }
     }
     fn hyp2f1(self, a: f64, b: f64, c: f64) -> f64 {
-        unsafe { hyp2f1(a, b, c, self) }
+        unsafe { unsafe_cephes_double::hyp2f1(a, b, c, self) }
     }
     fn hyp3f0(self, a: f64, b: f64, c: f64) -> f64 {
         let mut err = 0.0;
-        unsafe { threef0(a, b, c, self, &mut err) }
+        unsafe { unsafe_cephes_double::threef0(a, b, c, self, &mut err) }
     }
 
     fn norm(self) -> f64 {
-        unsafe { ndtr(self) }
+        unsafe { unsafe_cephes_double::ndtr(self) }
     }
     fn norm_inv(self) -> f64 {
-        unsafe { ndtri(self) }
+        unsafe { unsafe_cephes_double::ndtri(self) }
     }
 
     fn besselj(self, v: f64) -> f64 {
-        unsafe { jv(v, self) }
+        unsafe { unsafe_cephes_double::jv(v, self) }
     }
     fn bessely(self, v: f64) -> f64 {
-        unsafe { yv(v, self) }
+        unsafe { unsafe_cephes_double::yv(v, self) }
     }
     fn besseli(self, v: f64) -> f64 {
-        unsafe { iv(v, self) }
+        unsafe { unsafe_cephes_double::iv(v, self) }
     }
     fn besselk(self, n: i32) -> f64 {
-        unsafe { kn(n, self) }
+        unsafe { unsafe_cephes_double::kn(n, self) }
     }
 
     fn riemann_zeta(self) -> f64 {
-        unsafe { 1.0 + zetac(self) }
+        unsafe { 1.0 + unsafe_cephes_double::zetac(self) }
     }
     fn hurwitz_zeta(self, q: f64) -> f64 {
-        unsafe { zeta(self, q) }
+        unsafe { unsafe_cephes_double::zeta(self, q) }
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,6 +11,233 @@ fn assert_almost_eq<T: Float + FromPrimitive + Debug>(a: T, b: T) {
     }
 }
 
+mod cephes_double {
+    use special_fun::cephes_double;
+    use super::assert_almost_eq;
+    use std::f64::consts::PI;
+    #[test]
+    fn exp10() {
+        assert_almost_eq(cephes_double::exp10(0.0f64), 1.0);
+        assert_almost_eq(cephes_double::exp10(1.0f64), 10.0);
+        assert_almost_eq(cephes_double::exp10(1.2f64), 15.848931924611133);
+        assert_almost_eq(cephes_double::exp10(1.5f64), 31.622776601683793);
+        assert_almost_eq(cephes_double::exp10(308.2547155599167f64), 1.7976931348620926e308);
+    }
+
+    #[test]
+    fn expm1() {
+        assert_almost_eq(cephes_double::expm1(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::expm1(0.001f64), 0.0010005001667083846);
+        assert_almost_eq(cephes_double::expm1(0.1f64), 0.10517091807564771);
+        assert_almost_eq(cephes_double::expm1(1.0f64), 1.718281828459045);
+    }
+
+    #[test]
+    fn expx2(){
+        assert_almost_eq(cephes_double::expx2(2.0f64, 1), 54.598150033144236);
+        assert_almost_eq(cephes_double::expx2(2.0f64, 2), 54.598150033144236);
+        assert_almost_eq(cephes_double::expx2(2.0f64, -1), 1.0/54.598150033144236);
+        assert_almost_eq(cephes_double::expx2(2.0f64, -2), 1.0/54.598150033144236);
+    }
+
+    #[test]
+    fn ei(){
+        assert_almost_eq(cephes_double::ei(1.0f64), 1.89511781);
+        assert_almost_eq(cephes_double::ei(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::ei(0.6f64), 0.7698812899373594);
+    }
+
+    #[test]
+    fn erf() {
+        assert_almost_eq(cephes_double::erf(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::erf(0.5f64), 0.52049987781304654);
+        assert_almost_eq(cephes_double::erf(-0.5f64), -0.52049987781304654);
+        assert_almost_eq(cephes_double::erf(1.0f64), 0.84270079294971487);
+        assert_almost_eq(cephes_double::erf(-1.0f64), -0.84270079294971487);
+        assert_almost_eq(cephes_double::erf(10.0f64), 0.99999999999999999);
+        assert_almost_eq(cephes_double::erf(-10.0f64), -0.99999999999999999);
+    }
+
+    #[test]
+    fn erfc() {
+        assert_almost_eq(cephes_double::erfc(0.0f64), 1.0 - 0.0);
+        assert_almost_eq(cephes_double::erfc(0.5f64), 1.0 - 0.52049987781304654);
+        assert_almost_eq(cephes_double::erfc(-0.5f64), 1.0 + 0.52049987781304654);
+        assert_almost_eq(cephes_double::erfc(1.0f64), 1.0 - 0.84270079294971487);
+        assert_almost_eq(cephes_double::erfc(-1.0f64), 1.0 + 0.84270079294971487);
+        assert_almost_eq(cephes_double::erfc(10.0f64), 1.0 - 0.99999999999999999);
+        assert_almost_eq(cephes_double::erfc(-10.0f64), 1.0 + 0.99999999999999999);
+    }
+
+    #[test]
+    fn log1p() {
+        assert_almost_eq(cephes_double::log1p(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::log1p(1.0e-5_f64), 0.000009999950000333332);
+        assert_almost_eq(cephes_double::log1p(1.0f64), 0.6931471805599453);
+    }
+
+    #[test]
+    fn spence() {
+        assert_almost_eq(cephes_double::spence(0.0f64), PI*PI/6.0f64);
+        assert_almost_eq(cephes_double::spence(1.0f64), 0.0);
+        assert_almost_eq(cephes_double::spence(2.0f64), -PI*PI/12.0f64);
+    }
+
+    #[test]
+    fn cosm1() {
+        assert_almost_eq(cephes_double::cosm1(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::cosm1(1.0e-5_f64), -0.00000000004999999999958334);
+        assert_almost_eq(cephes_double::cosm1(0.1f64), -0.004995834721974235);
+    }
+
+    #[test]
+    fn sici() {
+        let mut si = 0.0_f64;
+        let mut ci = 0.0_f64;
+
+        cephes_double::sici(0.5_f64, &mut si, &mut ci);
+        assert_almost_eq(si, 0.49310741804306674);
+        assert_almost_eq(ci, -0.17778407880661287);
+
+        cephes_double::sici(0.1_f64, &mut si, &mut ci);
+        assert_almost_eq(si, 0.09994446110827694);
+        assert_almost_eq(ci, -1.7278683866572966);
+
+        cephes_double::sici(0.0_f64, &mut si, &mut ci);
+        assert_almost_eq(si, 0.0);
+    }
+
+    #[test]
+    fn shichi() {
+        let mut shi = 0.0_f64;
+        let mut chi = 0.0_f64;
+
+        cephes_double::shichi(0.5_f64, &mut shi, &mut chi);
+        assert_almost_eq(shi, 0.5069967498196671);
+        assert_almost_eq(chi, -0.05277684495649357);
+
+        cephes_double::shichi(0.1_f64, &mut shi, &mut chi);
+        assert_almost_eq(shi, 0.10005557222505701);
+        assert_almost_eq(chi, -1.7228683861943335);
+
+        cephes_double::shichi(0.0_f64, &mut shi, &mut chi);
+        assert_almost_eq(shi, 0.0);
+    }
+
+    #[test]
+    fn beta() {
+        assert_almost_eq(cephes_double::beta(5.0f64, 2.0f64), 0.03333333333333);
+        assert_almost_eq(cephes_double::beta(1.5f64, 2.0f64), 0.26666666666666);
+        assert_almost_eq(cephes_double::beta(1.0f64, 1.0f64), 1.0);
+    }
+
+    #[test]
+    fn incbet() {
+        assert_almost_eq(cephes_double::incbet(5.0f64, 2.0f64, 1.0f64), 1.0);
+        assert_almost_eq(cephes_double::incbet(5.0f64, 2.0f64, 0.5f64), 0.109375f64);
+        assert_almost_eq(cephes_double::incbet(1.0f64, 2.0f64, 0.2f64), 0.36f64);
+    }
+
+    #[test]
+    fn incbi() {
+        assert_almost_eq(cephes_double::incbi(5.0f64, 2.0f64, 1.0f64), 1.0);
+        assert_almost_eq(cephes_double::incbi(5.0f64, 2.0f64, 0.5f64), 0.73555001670434);
+        assert_almost_eq(cephes_double::incbi(1.0f64, 2.0f64, 0.2f64), 0.10557280900008412);
+        assert_almost_eq(cephes_double::incbi(2.0, 3.0, 0.6875f64), 0.5);
+    }
+
+    #[test]
+    fn gamma() {
+        assert_almost_eq(cephes_double::gamma(0.0f64), 1.0);
+        assert_almost_eq(cephes_double::gamma(0.5f64), PI.sqrt());
+        assert_almost_eq(cephes_double::gamma(1.0f64), 1.0);
+        assert_almost_eq(cephes_double::gamma(1.5f64), 0.5*PI.sqrt());
+        assert_almost_eq(cephes_double::gamma(2.0f64), 1.0);
+        assert_almost_eq(cephes_double::gamma(2.5f64), 0.75*PI.sqrt());
+        assert_almost_eq(cephes_double::gamma(3.0f64), 2.0);
+        assert_almost_eq(cephes_double::gamma(3.5f64), 15.0f64/8.0f64*PI.sqrt());
+        assert_almost_eq(cephes_double::gamma(4.0f64), 6.0);
+    }
+
+    #[test]
+    fn rgamma() {
+        assert_almost_eq(cephes_double::rgamma(0.0f64), 0.0);
+        assert_almost_eq(cephes_double::rgamma(0.5f64), 1.0/PI.sqrt());
+        assert_almost_eq(cephes_double::rgamma(1.0f64), 1.0);
+        assert_almost_eq(cephes_double::rgamma(1.5f64), 1.0/(0.5*PI.sqrt()));
+        assert_almost_eq(cephes_double::rgamma(2.0f64), 1.0);
+        assert_almost_eq(cephes_double::rgamma(2.5f64), 1.0/(0.75*PI.sqrt()));
+        assert_almost_eq(cephes_double::rgamma(3.0f64), 1.0/2.0);
+        assert_almost_eq(cephes_double::rgamma(3.5f64), 1.0/(15.0f64/8.0f64*PI.sqrt()));
+        assert_almost_eq(cephes_double::rgamma(4.0f64), 1.0/6.0);
+    }
+
+    #[test]
+    fn lgam() {
+        assert_almost_eq(cephes_double::lgam(0.5f64), PI.sqrt().ln());
+        assert_almost_eq(cephes_double::lgam(1.0f64), 0.0);
+        assert_almost_eq(cephes_double::lgam(1.5f64), (0.5*PI.sqrt()).ln());
+        assert_almost_eq(cephes_double::lgam(2.0f64), 0.0);
+        assert_almost_eq(cephes_double::lgam(2.5f64), (0.75f64*PI.sqrt()).ln());
+        assert_almost_eq(cephes_double::lgam(3.0f64), 2.0f64.ln());
+        assert_almost_eq(cephes_double::lgam(3.5f64), (15.0f64/8.0f64*PI.sqrt()).ln());
+        assert_almost_eq(cephes_double::lgam(4.0f64), 6.0f64.ln());
+    }
+
+    #[test]
+    fn igam() {
+        assert_almost_eq(cephes_double::igam(1.0f64, 1.0f64), 1.0f64 - (-1.0f64).exp());
+        assert_almost_eq(cephes_double::igam(1.0f64, 1.5f64), 1.0f64 - (-1.5f64).exp());
+        assert_almost_eq(cephes_double::igam(1.0f64, 2.0f64), 1.0f64 - (-2.0f64).exp());
+        assert_almost_eq(cephes_double::igam(0.5f64, 1.0f64),
+                         PI.sqrt() * cephes_double::erf(1.0f64.sqrt()) / cephes_double::gamma(0.5f64));
+        assert_almost_eq(cephes_double::igam(0.5f64, 1.5f64),
+                         PI.sqrt() * cephes_double::erf(1.5f64.sqrt()) / cephes_double::gamma(0.5f64));
+        assert_almost_eq(cephes_double::igam(0.5f64, 2.0f64),
+                         PI.sqrt() * cephes_double::erf(2.0f64.sqrt()) / cephes_double::gamma(0.5f64));
+    }
+
+    #[test]
+    fn igamc() {
+        assert_almost_eq(cephes_double::igamc(1.0f64, 1.0f64),  1.0 - (1.0f64 - (-1.0f64).exp()));
+        assert_almost_eq(cephes_double::igamc(1.0f64, 1.5f64), 1.0 - (1.0f64 - (-1.5f64).exp()));
+        assert_almost_eq(cephes_double::igamc(1.0f64, 2.0f64), 1.0 - (1.0f64 - (-2.0f64).exp()));
+        assert_almost_eq(cephes_double::igamc(0.5f64, 1.0f64),
+                         1.0 - (PI.sqrt() * cephes_double::erf(1.0f64.sqrt()) / cephes_double::gamma(0.5f64)));
+        assert_almost_eq(cephes_double::igamc(0.5f64, 1.5f64),
+                         1.0 - (PI.sqrt() * cephes_double::erf(1.5f64.sqrt()) / cephes_double::gamma(0.5f64)));
+        assert_almost_eq(cephes_double::igamc(0.5f64, 2.0f64),
+                         1.0 - (PI.sqrt() * cephes_double::erf(2.0f64.sqrt()) / cephes_double::gamma(0.5f64)));
+    }
+
+    #[test]
+    fn igami() {
+        assert_almost_eq(cephes_double::igami(0.5f64, 0.1f64), 1.3527717270477);
+        assert_almost_eq(cephes_double::igami(0.5f64, 0.2f64), 0.8211872075749);
+        assert_almost_eq(cephes_double::igami(0.2f64, 0.1f64), 0.6049023209866);
+    }
+
+    #[test]
+    fn psi() {
+        let euler = 0.5772156649015329;
+        assert_almost_eq(cephes_double::psi(1.0f64), -euler);
+        assert_almost_eq(cephes_double::psi(0.5f64), -2.0*2.0f64.ln() - euler);
+        assert_almost_eq(cephes_double::psi(20.0f64), 2.970523992242149);
+    }
+
+    #[test]
+    fn fac() {
+        assert_almost_eq(cephes_double::fac(0i32), 1.0);
+        assert_almost_eq(cephes_double::fac(1i32), 1.0);
+        assert_almost_eq(cephes_double::fac(2i32), 2.0);
+        assert_almost_eq(cephes_double::fac(3i32), 6.0);
+        assert_almost_eq(cephes_double::fac(4i32), 24.0);
+        assert_almost_eq(cephes_double::fac(5i32), 120.0);
+        assert_almost_eq(cephes_double::fac(6i32), 720.0);
+        assert_almost_eq(cephes_double::fac(20i32), 2432902008176640000.0);
+    }
+}
+
 mod double {
     use special_fun::FloatSpecial;
     use super::assert_almost_eq;


### PR DESCRIPTION
**What does this do?** This PR does two things. First, it wraps the external cephes functions in a module called `unsafe_cephes_double`, which allows me to relatively easily write wrappers that respect the raw cephes interface.

**Why is this better than the alternative?** It provides more flexibility for the end user.

@vks If you agree with this move forward, I'll go ahead and add in the rest of the cephes functions over the next week. Additionally, I can add tests and and wrappers in the trait style you have implemented.