### PR TITLE
Add elliptic integral functions to safe api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,21 @@
+[[package]]
+name = "cc"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "special-fun"
+version = "0.2.0"
+dependencies = [
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[metadata]
+"checksum cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -733,6 +733,32 @@ pub mod cephes_double {
     pub fn fac(i: i32) -> f64 {
         unsafe { unsafe_cephes_double::fac(i) }
     }
+
+    // Elliptic functions
+    /// Incomplete elliptic integral of the first kind.
+    pub fn ellik(phi: f64, m: f64) -> f64 {
+        unsafe { unsafe_cephes_double::ellik(phi, m) }
+    }
+
+    /// Incomplete elliptic integral of the second kind.
+    pub fn ellie(phi: f64, m: f64) -> f64 {
+        unsafe { unsafe_cephes_double::ellie(phi, m) }
+    }
+
+    /// Complete elliptic integral of the first kind.
+    pub fn ellpk(m1: f64) -> f64 {
+        unsafe { unsafe_cephes_double::ellpk(m1) }
+    }
+
+    /// Complete elliptic integral of the second kind.
+    pub fn ellpe(m1: f64) -> f64 {
+        unsafe { unsafe_cephes_double::ellpe(m1) }
+    }
+
+    /// Jacobian elliptic function.
+    pub fn ellpj(u: f64, m: f64, sn: &mut f64, cn: &mut f64, dn: &mut f64, phi: &mut f64) -> i32 {
+        unsafe { unsafe_cephes_double::ellpj(u, m, sn, cn, dn, phi) }
+    }
 }
 
 /// Low-level bindings to single-precision Cephes functions.
@@ -1430,6 +1456,32 @@ pub mod cephes_single {
     /// Factorial function.
     pub fn fac(i: i32) -> f32 {
         unsafe { unsafe_cephes_single::facf(i) }
+    }
+
+    // Elliptic functions
+    /// Incomplete elliptic integral of the first kind.
+    pub fn ellik(phi: f32, m: f32) -> f32 {
+        unsafe { unsafe_cephes_single::ellikf(phi, m) }
+    }
+
+    /// Incomplete elliptic integral of the second kind.
+    pub fn ellie(phi: f32, m: f32) -> f32 {
+        unsafe { unsafe_cephes_single::ellief(phi, m) }
+    }
+
+    /// Complete elliptic integral of the first kind.
+    pub fn ellpk(m1: f32) -> f32 {
+        unsafe { unsafe_cephes_single::ellpkf(m1) }
+    }
+
+    /// Complete elliptic integral of the second kind.
+    pub fn ellpe(m1: f32) -> f32 {
+        unsafe { unsafe_cephes_single::ellpef(m1) }
+    }
+
+    /// Jacobian elliptic function.
+    pub fn ellpj(u: f32, m: f32, sn: &mut f32, cn: &mut f32, dn: &mut f32, phi: &mut f32) -> i32 {
+        unsafe { unsafe_cephes_single::ellpjf(u, m, sn, cn, dn, phi) }
     }
 }
 


### PR DESCRIPTION
I just added the functions I need for now.

How did you do tests? Do reference calculations in python for example?
I can add those if needed!

If there is something I am missing, let me know, I'll update this PR.